### PR TITLE
feat: ensure wraps only promise-returning functions and handles non-promise returns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,8 @@ pnpm-debug.log*
 
 # Idea/VSCode settings
 .idea/
-.vscode/
+.vscode/*
+!.vscode/settings.json
 
 # Miscellaneous
 *.tgz

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,10 @@
+{
+    "singleQuote": true,
+    "vueIndentScriptAndStyle": true,
+    "singleAttributePerLine": true,
+    "htmlWhitespaceSensitivity": "strict",
+    "arrowParens": "avoid",
+    "bracketSameLine": true,
+    "jsxSingleQuote": true,
+    "proseWrap": "always"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-use-async-data-wrapper",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "A utility to wrap Promise-returning functions with useAsyncData for Nuxt",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -25,10 +25,11 @@
     "url": "https://github.com/leynier/nuxt-use-async-data-wrapper.git"
   },
   "peerDependencies": {
-    "vue": "^3.0.0",
-    "nuxt": "^3.0.0"
+    "nuxt": "^3.0.0",
+    "vue": "^3.0.0"
   },
   "devDependencies": {
+    "prettier": "^3.3.3",
     "typescript": "^5.7.2",
     "vue": "^3.5.13"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ importers:
         specifier: ^3.0.0
         version: 3.14.1592(@parcel/watcher@2.5.0)(@types/node@22.9.3)(ioredis@5.4.1)(magicast@0.3.5)(rollup@4.27.4)(terser@5.36.0)(typescript@5.7.2)(vite@5.4.11(@types/node@22.9.3)(terser@5.36.0))
     devDependencies:
+      prettier:
+        specifier: ^3.3.3
+        version: 3.3.3
       typescript:
         specifier: ^5.7.2
         version: 5.7.2
@@ -2393,6 +2396,11 @@ packages:
   postcss@8.4.49:
     resolution: {integrity: sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==}
     engines: {node: ^10 || ^12 || >=14}
+
+  prettier@3.3.3:
+    resolution: {integrity: sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==}
+    engines: {node: '>=14'}
+    hasBin: true
 
   pretty-bytes@6.1.1:
     resolution: {integrity: sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ==}
@@ -5704,6 +5712,8 @@ snapshots:
       nanoid: 3.3.7
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  prettier@3.3.3: {}
 
   pretty-bytes@6.1.1: {}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,10 @@ export type AsyncDataWrapper<T> = {
          * @param options - Optional AsyncDataOptions to configure useAsyncData.
          * @returns AsyncDataResult containing the data, pending state, and error.
          */
-        (argsSupplier: () => Args, options?: AsyncDataOptions<R>) => AsyncDataResult<R>
+        (
+          argsSupplier: () => Args,
+          options?: AsyncDataOptions<R>,
+        ) => AsyncDataResult<R>
     : never;
 };
 
@@ -56,13 +59,15 @@ export type AsyncDataWrapper<T> = {
  * const wrappedObject = useAsyncDataWrapper(originalObject);
  * ```
  */
-export function useAsyncDataWrapper<T extends Record<string, any>>(obj: T): AsyncDataWrapper<T> {
+export function useAsyncDataWrapper<T extends Record<string, any>>(
+  obj: T,
+): AsyncDataWrapper<T> {
   const composable = {} as AsyncDataWrapper<T>;
   const proto = Object.getPrototypeOf(obj);
 
   // Get function names from the object's prototype, excluding the constructor
   const functionNames = Object.getOwnPropertyNames(proto).filter(
-    key => key !== 'constructor' && typeof obj[key] === 'function'
+    key => key !== 'constructor' && typeof obj[key] === 'function',
   );
 
   for (const key of functionNames) {
@@ -89,7 +94,9 @@ export function useAsyncDataWrapper<T extends Record<string, any>>(obj: T): Asyn
         // Reactive reference to arguments
         const argsRef = computed(() => argsSupplier!());
         // Unique key for useAsyncData
-        const dataKeyRef = computed(() => `${key}-${JSON.stringify(argsRef.value)}`);
+        const dataKeyRef = computed(
+          () => `${key}-${JSON.stringify(argsRef.value)}`,
+        );
 
         // Call useAsyncData with the generated key and function
         const asyncDataResult = useAsyncData(
@@ -100,7 +107,7 @@ export function useAsyncDataWrapper<T extends Record<string, any>>(obj: T): Asyn
             watch: [argsRef],
             // Spread additional options
             ...options,
-          }
+          },
         );
 
         return asyncDataResult;

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,16 +10,18 @@ type AsyncDataResult<T> = AsyncData<T, Error>;
 /**
  * Transforms an object's Promise-returning functions into functions compatible with useAsyncData.
  *
+ * Only includes functions that return Promises; other properties are excluded.
+ *
  * For each function in the object:
  * - If the function returns a Promise and takes no arguments, it becomes a function that accepts optional AsyncDataOptions.
  * - If the function returns a Promise and takes arguments, it becomes a function that accepts an argsSupplier and optional AsyncDataOptions.
  *
- * This allows you to use the functions within a Nuxt application, leveraging the reactivity and data fetching capabilities of useAsyncData.
- *
  * @template T - The type of the object.
  */
 export type AsyncDataWrapper<T> = {
-  [K in keyof T]: T[K] extends (...args: infer Args) => Promise<infer R>
+  [K in keyof T as T[K] extends (...args: any[]) => Promise<any>
+    ? K
+    : never]: T[K] extends (...args: infer Args) => Promise<infer R>
     ? Args extends []
       ? /**
          * Functions without arguments.

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,7 +101,11 @@ export function useAsyncDataWrapper<T extends Record<string, any>>(
         // Call useAsyncData with the generated key and function
         const asyncDataResult = useAsyncData(
           dataKeyRef.value,
-          () => originalFunction(...unref(argsRef)),
+          () => {
+            const result = originalFunction(...unref(argsRef));
+            // Ensure we return a Promise
+            return result instanceof Promise ? result : Promise.resolve(result);
+          },
           {
             // Re-execute when arguments change
             watch: [argsRef],
@@ -113,10 +117,18 @@ export function useAsyncDataWrapper<T extends Record<string, any>>(
         return asyncDataResult;
       } else {
         // For functions without arguments
-        const asyncDataResult = useAsyncData(key, () => originalFunction(), {
-          // Spread additional options
-          ...options,
-        });
+        const asyncDataResult = useAsyncData(
+          key,
+          () => {
+            const result = originalFunction();
+            // Ensure we return a Promise
+            return result instanceof Promise ? result : Promise.resolve(result);
+          },
+          {
+            // Spread additional options
+            ...options,
+          },
+        );
 
         return asyncDataResult;
       }


### PR DESCRIPTION

This pull request includes several changes to enhance code formatting and improve the `useAsyncDataWrapper` utility. The most important changes include adding Prettier configuration, updating dependencies, and refining the `useAsyncDataWrapper` function to ensure better compatibility and functionality.

### Functionality Enhancements:
* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R13-R24): Improved the `useAsyncDataWrapper` function to ensure it only includes functions that return Promises and added better handling for functions with and without arguments. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R13-R24) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L36-R41) [[3]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L59-R72) [[4]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L92-R133)

### Code Formatting Improvements:
* [`.prettierrc`](diffhunk://#diff-663ade211b3a1552162de21c4031fcd16be99407aae5ceecbb491a2efc43d5d2R1-R10): Added a Prettier configuration file with specific formatting rules.
* [`.vscode/settings.json`](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357R1-R4): Configured VSCode to format code on save using Prettier.

### Dependency Updates:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version to `1.1.0`, added Prettier as a dev dependency, and reordered `peerDependencies`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L28-R32)
* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR15-R17): Added Prettier to the `importers`, `packages`, and `snapshots` sections. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR15-R17) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2400-R2404) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR5716-R5717)